### PR TITLE
BUGFIX: Stop propagation of click events for close and toggle

### DIFF
--- a/src/DropDown/wrapper.js
+++ b/src/DropDown/wrapper.js
@@ -50,8 +50,14 @@ export class DropDownWrapper extends Component {
         super(props, context);
 
         this.state = {isOpen: Boolean(props.isOpen)};
-        this.handleToggle = this.toggle.bind(this);
-        this.handleClose = this.close.bind(this);
+        this.handleToggle = (event) => {
+            this.toggle();
+            event.stopPropagation();
+        };
+        this.handleClose = (event) => {
+            this.close();
+            event.stopPropagation();
+        };
         this.handleClickOutside = this.close.bind(this);
     }
 


### PR DESCRIPTION
This should fix the issue with nested SelectBox inside a DropDown